### PR TITLE
Add a `make install` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
+PLATFORM?=$(shell uname | tr [A-Z] [a-z])
+export GO111MODULE = on
+
 .PHONY: default
 default:
-	@make $(shell uname | tr [A-Z] [a-z])
+	@make $(PLATFORM)
 
-.PHONY: zip
-zip: darwin linux windows
-	mkdir -p build/releases
-	(cd build/linux; zip -r ../releases/dcos-http-cli.linux.zip .)
-	(cd build/darwin; zip -r ../releases/dcos-http-cli.darwin.zip .)
-	(cd build/windows; zip -r ../releases/dcos-http-cli.windows.zip .)
+.PHONY: install
+install:
+	@make plugin
+	dcos plugin add -u ./build/plugins/dcos-http-cli.$(PLATFORM).zip
+
+.PHONY: plugin
+plugin: $(PLATFORM)
+	mkdir -p build/plugins
+	(cd build/$(PLATFORM); zip -r ../plugins/dcos-http-cli.$(PLATFORM).zip .)
 
 .PHONY: darwin linux windows
 darwin linux windows:

--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ In order to run the plugin from sources, you must first have the DC/OS CLI insta
 Then you can build the plugin and add it to your CLI:
 
 ```console
-$ make zip
-$ dcos plugin add -u ./build/releases/dcos-http-cli.darwin.zip
+$ make install
 ```
 
 It can now be invoked through `dcos http [...]`


### PR DESCRIPTION
It is building the plugin ZIP and then running the `dcos plugin add` command with the generated artifact.