### PR TITLE
Hide headers per default; Add flag `-i` for showing headers

### DIFF
--- a/pkg/cmd/http.go
+++ b/pkg/cmd/http.go
@@ -18,7 +18,7 @@ import (
 func NewHTTPCommand() *cobra.Command {
 	var method, data string
 	var headers []string
-	var suppressHeaders bool
+	var includeHeaders bool
 
 	cmd := &cobra.Command{
 		Use:   "http <path>",
@@ -62,11 +62,11 @@ func NewHTTPCommand() *cobra.Command {
 			}
 			defer resp.Body.Close()
 
-			return dumpResponse(resp, suppressHeaders)
+			return dumpResponse(resp, includeHeaders)
 		},
 	}
 
-	cmd.Flags().BoolVarP(&suppressHeaders, "suppress-headers", "s", false, "Suppress response headers in output")
+	cmd.Flags().BoolVarP(&includeHeaders, "include", "i", false, "Include HTTP headers in the output")
 	cmd.Flags().StringVarP(&data, "data", "d", "", "HTTP POST data")
 	cmd.Flags().StringVarP(&method, "request", "X", "GET", "Specify request command to use")
 	cmd.Flags().StringSliceVarP(&headers, "header", "H", nil, "Pass custom header(s) to server")
@@ -74,8 +74,8 @@ func NewHTTPCommand() *cobra.Command {
 	return cmd
 }
 
-func dumpResponse(resp *http.Response, suppressHeaders bool) error {
-	if !suppressHeaders {
+func dumpResponse(resp *http.Response, includeHeaders bool) error {
+	if includeHeaders {
 		respDump, err := httputil.DumpResponse(resp, false)
 		if err != nil {
 			return err


### PR DESCRIPTION
This changes the default behaviour of this plugin in that now HTTP headers are mot peintedper default. This is very useful when you want to process the output with `jq` for instance. Also, it aligns more with `curl`s behaviour. The `-i`/`--include` flag shows headers.